### PR TITLE
Only include the admin file on the back end

### DIFF
--- a/instagram-feed.php
+++ b/instagram-feed.php
@@ -26,8 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 define( 'SBIVER', '1.5.1' );
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
 //Include admin
-include dirname( __FILE__ ) .'/instagram-feed-admin.php';
+if ( is_admin() ) include dirname( __FILE__ ) .'/instagram-feed-admin.php';
 
 // Add shortcodes
 add_shortcode('instagram-feed', 'display_instagram');


### PR DESCRIPTION
Saves an unnecessary include on all front end requests. It maybe be a minor thing, but ever little bit of performance helps.

Note that I haven't had time to test this change, but as long as the admin file doesn't contain any code that needs to run on the front end (it probably shouldn't), it's pretty safe to assume we only have to include it on the back end.